### PR TITLE
simplifies the update action in pieces_controller and Players turn feature

### DIFF
--- a/app/assets/javascripts/game.js
+++ b/app/assets/javascripts/game.js
@@ -4,10 +4,10 @@ function render_chess_board() {
 
   $.get(url, function(data) {
     $(".chess_board_partial").empty();
-    $(".chess_board_partial").append(data.html);
+    $(".chess_board_partial").append(data.chess_board);
   }).done(function() {
     draggable_droppable();
-  });
+  })
 }
 
 function draggable_droppable() {
@@ -37,8 +37,8 @@ function piece_type_buttons_listner(pawn_id) {
       data: {},
       dataType: 'json',
       success: function(data) {
-
         $('.close').trigger("click");
+        $(".notice-alert").empty().append(data.notifications);
         render_chess_board();
       }
     });
@@ -56,23 +56,18 @@ function handleDropEvent( event, ui ) {
   $.ajax({
         type: 'PUT', 
         statusCode: {
-          205: function() {
-            render_chess_board();
-          },
-          422: function() {
-            render_chess_board();   
-          },
           206: function(data){
             var pawn_id = data["pawn_id"];
             trigger_pawn_promotion_modal(pawn_id);
-          },
-          204: function() {
-            alert("Check Mate!");
           }
         },
         url: draggable.data('update-url'),
         dataType: 'json',
-        data: { piece: {x_coord: x, y_coord: y}}
+        data: { piece: {x_coord: x, y_coord: y}}, 
+        success: function (data) {
+          render_chess_board();
+          $(".notice-alert").empty().append(data.notifications);
+        }  
   });
 }
 
@@ -82,12 +77,10 @@ function check_pawn_promtion() {
     type: 'PATCH',
     url: check_pawn_promotion_url,
     dataType: 'json',
-    statusCode: {
-      206: function(data){
-        var pawn_id = data["pawn_id"];
+    success : function(data){
+        var pawn_id = data.pawn_id;
         trigger_pawn_promotion_modal(pawn_id);
       }
-    }
   });
 }
 

--- a/app/assets/stylesheets/master.css.scss
+++ b/app/assets/stylesheets/master.css.scss
@@ -8,3 +8,7 @@
 	@extend .col-sm-offset-3;
 }
 
+ul {
+	list-style: none;
+}
+

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -30,7 +30,7 @@ class GamesController < ApplicationController
 			if pawn_id == -1
 				render :nothing
 			else
-				render :json => {:pawn_id => pawn_id, :message => "pawn promoted"}, :status => :partial_content
+				render :json => {:pawn_id => pawn_id }
 			end
 		else
 			render :nothing
@@ -42,17 +42,20 @@ class GamesController < ApplicationController
 	def join
 		if @game.not_white_player?(current_user)
 			@game.update_attributes(:black_player => current_user )
-		end
-		redirect_to game_path(@game), action: 'get'
+			flash[:notice] = "You joined the game: #{@game.title}"
+			redirect_to game_path(@game), action: 'get'
+		else
+			flash[:alert] = "Cannot join the game, you are already in this game."
+			redirect_to root_path
+		end		
 	end
 
 	def render_chess_board
 		render :json => {
-			:html => render_to_string( {
+				:chess_board => render_to_string( {
 				:partial => "chess_board",
 				:locals => { game: current_game }
-			})
-
+				})
 		}	
 	end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,9 +1,25 @@
 class WelcomeController < ApplicationController
   def index
     @available_games = Game.where(:black_player_id => nil)
+
+    if current_user
+    	@recent_game = Game.where(:white_player_id => current_user.id).last
+    end
     @game = Game.new
   end
 
   def about
   end
+
+def quick_play
+	@game = Game.where(:black_player_id => nil).last
+	if @game.not_white_player?(current_user)
+		@game.update_attributes(:black_player => current_user )
+		flash[:notice] = "You joined the game: #{@game.title}"
+		redirect_to game_path(@game), action: 'get'
+	else
+		flash[:alert] = "Sorry, No game is available now. Please check later or create your own game!"
+		redirect_to root_path
+	end	
+end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -120,7 +120,6 @@ class Piece < ActiveRecord::Base
         elsif equal_to_original_moves?(new_x, new_y)
           return true
         else 
-          puts "yes"
           return false
         end
       else

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -12,10 +12,12 @@
   <% unless @game.black_player.nil?%>
     <%= @game.black_player.email %>
   <% else %>
-    <%= link_to "Find a Friend", "#", :class => "btn btn-sm btn-default" %>
+    <%= link_to "Find a Friend", "#", :class => "btn btn-md btn-default" %>
   <% end %>
     <br class="clear"/>
-
+    <br />
+    <br />
+    <br />
 </div>
 
 

--- a/app/views/layouts/_notice_alert.html.erb
+++ b/app/views/layouts/_notice_alert.html.erb
@@ -1,0 +1,7 @@
+<% if notice.present? %>
+	<p class="alert alert-info"><%= notice %></p>
+<% end %>
+			
+<% if alert.present? %>
+	<p class="alert alert-danger"><%= alert %></p>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,7 @@
 	<body>
 		<%= render "layouts/nav"%>
 		<div class= "notice-alert col-xs-12 col-sm-6 col-sm-offset-3" >
-			<% if notice.present? %>
-			  <p class="alert alert-info"><%= notice %></p>
-			<% end %>
-			<% if alert.present? %>
-			  <p class="alert alert-danger"><%= alert %></p>
-			<% end %>
+			<%= render "layouts/notice_alert"%>
 		</div>
 
 		<br class="clear"/>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -8,12 +8,11 @@
           <%= link_to "Create a Game", "#", :class => "btn btn-success btn-lg col-xs-12 col-sm-8 col-sm-offset-2", :data => {:toggle => "modal", :target => "#newGameModal"} %>
           <br class="clear" />
           <br /> 
-          <%= link_to "Quick Play", "#", :class => "btn btn-info btn-lg col-xs-12 col-sm-8 col-sm-offset-2" %>
+          <%= link_to "Quick Play", welcome_quick_play_path, method: :patch, :class => "btn btn-info btn-lg col-xs-12 col-sm-8 col-sm-offset-2" %>
       <% else %>
         <%= link_to "Sign Up", new_user_registration_path, :class => "btn btn-warning btn-lg col-xs-12 col-sm-10 col-sm-offset-1"%>
         <br class="clear"/>
         <br />
-        <%= link_to "Sign in with Facebook", user_omniauth_authorize_path(:facebook), :class => "btn-lg btn btn-primary col-xs-12 col-sm-10 col-sm-offset-1"%>
       <% end %>
     </div>
   </div>
@@ -21,24 +20,28 @@
   <br />
   <br />
 
-  <div class="booyah-box col-xs-10 col-xs-offset-1">
-
+  <div class="booyah-box col-xs-12 col-sm-8 col-sm-offset-2">
+    <% if current_user && !@recent_game.nil? %>
+      <h4 class="text-center">Go to recent game: <%= link_to @recent_game.title, game_path(@recent_game), method: :get %></h4>
+    <% end %>
+    <br />
+    <br />
     <h2 class="text-center">Open Tournaments</h2>
     <hr />
 
     <% if !@available_games.present? %>
       <%= "There are currently no open tournaments. Please check back later." %>
-    <% end %>
-
+    <% else %>
+    <ul>
     <% @available_games.each do |game| %>
-      <div class="col-sm-8 col-xs-12">
-        <%= game.white_player_id %>
-      </div>
-      <div class="col-sm-4 col-xs-12 text-center">
-        <% if current_user %>
-         
-        <% end %> 
-      </div>
+        <li>
+          <%= link_to "JOIN", game_join_path(game), method: :patch, :class => "btn btn-sm btn-danger pull-right"%>
+          <h4><%= game.title %><h4>
+          White Player: <%= game.white_player.email %>
+        </li> 
+        <br />  
+    <% end %>
+    </ul>
     <% end %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resources :games, :only => [:new, :create, :show, :update ]
   patch "games/:id/join" => 'games#join', :as => 'game_join'
+  patch "welcome/quick_play" => 'welcome#quick_play', :as => 'welcome_quick_play'
 
   get "games/:id/render_chess_board" => 'games#render_chess_board', :as => "game_render_chess_board"
 

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -38,7 +38,6 @@ class GamesControllerTest < ActionController::TestCase
     assert_no_difference 'Game.count' do
       patch :join, :id => game.id
     end
-    puts game.inspect
     assert_equal user2, game.reload.black_player
     assert_redirected_to game_path(game)
   end

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -46,9 +46,8 @@ class PiecesControllerTest < ActionController::TestCase
     piece4 = game.pieces.create(:x_coord => 0, :y_coord => 0, :piece_type => 'King', :color => "black")
     piece5 = game.pieces.create(:x_coord => 7, :y_coord => 7, :piece_type => 'King', :color => "white")
     put :update, id: piece.id, :piece => {x_coord: 3, y_coord: 2}
-    assert_response :unprocessable_entity
+    assert_equal "#{piece.piece_type}: Invalid move!", flash[:alert] 
     response = ActiveSupport::JSON.decode @response.body
-    assert response["message"].present?
   end
 
   test "capture_method" do


### PR DESCRIPTION
Simplifies the update action in pieces_controller. It does not render statusCode anymore except for pawn promotion. Appropriate flash messages will be rendered instead. Therefore, in game.js, for the ajax request which invokes the update action in the handleDropEvent function, its success callback will simply empty the div notice-alert, append the new flash message and reload the div chess_board_partial.

If there is a black player in the game, the player turns feature will be activated, so both players need to follow the turn to make moves, but before a black player join the game, white player can move all pieces as long as the moves are valid.

QuickPlay feature: A quick play button is added on the index welcome page if the user is signed in. This allows a user to join a game immediately as long as there is an available game.

Join game feature: A join button is added besides each games that do not have a black player on the index welcome page. If the user is not in the game already, the user can join the game and be redirected to the game page. 